### PR TITLE
Fix query parameters not being sent on API requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run check
         run: npm run lint:check
 
+      - name: Run tests
+        run: npm test
+
   publish-dry-run:
     needs: [ check ]
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev": "npm run build -- --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint:check": "eslint . --max-warnings 0"
+    "lint:check": "eslint . --max-warnings 0",
+    "test": "npm run build && node --test build/**/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/src/helpers/query-params.test.ts
+++ b/src/helpers/query-params.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { appendQueryParams, buildQueryString } from "./query-params.js";
+
+describe("buildQueryString", () => {
+  it("returns an empty string when there are no query params", () => {
+    assert.equal(buildQueryString({}), "");
+  });
+
+  it("skips null values", () => {
+    assert.equal(buildQueryString({ reason: null }), "");
+  });
+
+  it("serializes string query params", () => {
+    assert.equal(
+      buildQueryString({ reason: "Enable flag for testing" }),
+      "reason=Enable+flag+for+testing"
+    );
+  });
+
+  it("serializes boolean and number query params", () => {
+    assert.equal(
+      buildQueryString({ cleanupAuditLogs: true, staleFlagAgeDays: 30 }),
+      "cleanupAuditLogs=true&staleFlagAgeDays=30"
+    );
+  });
+
+  it("serializes array query params as repeated keys", () => {
+    assert.equal(
+      buildQueryString({ ignoredEnvironmentIds: ["env-1", "env-2"] }),
+      "ignoredEnvironmentIds=env-1&ignoredEnvironmentIds=env-2"
+    );
+  });
+});
+
+describe("appendQueryParams", () => {
+  it("returns the original path when there are no query params", () => {
+    const path = "/v2/environments/env-id/settings/123/value";
+    assert.equal(appendQueryParams(path, {}), path);
+  });
+
+  it("appends query params to the path", () => {
+    const path = "/v2/environments/env-id/settings/123/value";
+    assert.equal(
+      appendQueryParams(path, { reason: "Testing change" }),
+      "/v2/environments/env-id/settings/123/value?reason=Testing+change"
+    );
+  });
+});

--- a/src/helpers/query-params.ts
+++ b/src/helpers/query-params.ts
@@ -1,0 +1,41 @@
+export type QueryParamValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | (string | number | boolean)[];
+
+export function buildQueryString(queryParams: Record<string, QueryParamValue>): string {
+  return new URLSearchParams(
+    Object.entries(queryParams).flatMap(([key, value]) => {
+      if (value == null) {
+        return [];
+      }
+
+      if (Array.isArray(value)) {
+        return value.map((item) => [
+          key,
+          typeof item === "string" ? item : JSON.stringify(item),
+        ] as [string, string]);
+      }
+
+      const stringValue = typeof value === "string"
+        ? value
+        : typeof value === "number" || typeof value === "boolean"
+          ? String(value)
+          : JSON.stringify(value);
+
+      return [[key, stringValue] as [string, string]];
+    })
+  ).toString();
+}
+
+export function appendQueryParams(path: string, queryParams: Record<string, QueryParamValue>): string {
+  const queryString = buildQueryString(queryParams);
+  if (!queryString) {
+    return path;
+  }
+
+  return `${path}?${queryString}`;
+}

--- a/src/tools/configcat-api.ts
+++ b/src/tools/configcat-api.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z, ZodError } from "zod";
 import type { ZodRawShape } from "zod";
+import { appendQueryParams } from "../helpers/query-params.js";
 import type { HttpClient } from "../http";
 
 // Type definition for JSON objects
@@ -2001,6 +2002,8 @@ async function executeApiTool(
     if (urlPath.includes("{")) {
       throw new Error(`Failed to resolve path parameters: ${urlPath}`);
     }
+
+    urlPath = appendQueryParams(urlPath, queryParams);
 
     // Handle request body if needed
     if (typeof validatedArgs["requestBody"] !== "undefined") {


### PR DESCRIPTION
> AI-generated content — authored by an AI agent on behalf of the user.

## Summary

- Fix a bug where `executeApiTool` collected query parameters (e.g. `reason`) but never appended them to the request URL
- Environments with `reasonRequired: true` returned `400 {"Reason":["Reason required."]}` for write tools like `update-setting-value-v2`, even when `reason` was provided
- Extract query-string building into `src/helpers/query-params.ts` with unit tests
- Add `npm test` script and run tests in CI

## Root cause

`queryParams` was populated from `executionParameters` with `in: "query"`, but the map was never serialized onto `urlPath` before calling `http.request()`.

## Test plan

- [x] `npm test` — 7 unit tests for `buildQueryString` and `appendQueryParams`
- [x] `npm run lint:check`
- [x] Manual verification: `update-setting-value-v2` with `reason` on Staging succeeds (HTTP 200)


Made with [Cursor](https://cursor.com)